### PR TITLE
Ensure word boundaries around shorten filter

### DIFF
--- a/lib/html/pipeline/abbr_filter.rb
+++ b/lib/html/pipeline/abbr_filter.rb
@@ -68,7 +68,7 @@ module HTML
       # @return [String] html with abbreviation tags
       def abbr_filter(content, abbr, full)
         target_html = abbr_tag(abbr, full)
-        content.gsub(abbr) { |_| target_html }
+        content.gsub(/\b#{abbr}\b/) { |_| target_html }
       end
 
       # Return html string to use as an abbr tag

--- a/lib/html/pipeline/shorten_filter.rb
+++ b/lib/html/pipeline/shorten_filter.rb
@@ -16,7 +16,7 @@ module HTML
 
       def abbr_filter(content, abbr, full)
         target_html = abbr_tag(abbr, full)
-        content.gsub(full) { |_| target_html }
+        content.gsub(/\b#{full}\b/) { |_| target_html }
       end
     end
   end

--- a/test/html/pipeline/shorten_filter_test.rb
+++ b/test/html/pipeline/shorten_filter_test.rb
@@ -27,13 +27,53 @@ class Html::Pipeline::ShortenFilterTest < Minitest::Test
     assert_equal %(<p><abbr title="Hypertext">HTML</abbr> is great</p>), result
   end
 
+  def test_abbr_spaces
+    result = html_from_fragment("<p>Hyper text is great</p><p>*[HTML]: Hyper text</p>")
+    assert_equal %(<p><abbr title="Hyper text">HTML</abbr> is great</p>), result
+  end
+
   def test_abbr_other_abbr
     result = html_from_fragment("<p>Hypertext is great\n*[HTML]: Hypertext\n*[CSS]: Stylesheets</p>")
     assert_equal %(<p><abbr title="Hypertext">HTML</abbr> is great</p>), result
   end
 
-  def test_multi_abbr_other_abbr
+  def test_abbr_punct
+    result = html_from_fragment(%(<p>"Hyper text!" is great</p><p>*[HTML]: Hyper text</p>))
+    assert_equal %(<p>"<abbr title="Hyper text">HTML</abbr>!" is great</p>), result
+  end
+
+  # multiple
+
+  def test_multiple_abbr
+    html=%(<abbr title="Hypertext">HTML</abbr>)
+    css=%(<abbr title="Stylesheets">CSS</abbr>)
     result = html_from_fragment("<p>Hypertext and Stylesheets are great\n*[HTML]: Hypertext\n*[CSS]: Stylesheets</p>")
-    assert_equal %(<p><abbr title="Hypertext">HTML</abbr> and <abbr title="Stylesheets">CSS</abbr> are great</p>), result
+    assert_equal %(<p>#{html} and #{css} are great</p>), result
+  end
+
+  def test_duplicate_abbr
+    agree=%(<abbr title="agree">YES</abbr>)
+    result = html_from_fragment("<p>agree agree\n*[YES]: agree</p><p>agree</p>")
+    assert_equal %(<p>#{agree} #{agree}</p><p>#{agree}</p>), result
+  end
+
+  def test_similar_abbr
+    agree=%(<abbr title="agree">AG</abbr>)
+    disagree=%(<abbr title="disagree">NAG</abbr>)
+    result = html_from_fragment("<p>agree disagree agree\n*[AG]: agree\n*[NAG]: disagree</p><p>agree</p><p>disagree</p>")
+    assert_equal %(<p>#{agree} #{disagree} #{agree}</p><p>#{agree}</p><p>#{disagree}</p>), result
+  end
+
+  def test_similar_abbr_rev
+    agree=%(<abbr title="agree">AG</abbr>)
+    disagree=%(<abbr title="disagree">NAG</abbr>)
+    result = html_from_fragment("<p>agree disagree agree\n*[NAG]: disagree\n*[AG]: agree</p><p>agree</p><p>disagree</p>")
+    assert_equal %(<p>#{agree} #{disagree} #{agree}</p><p>#{agree}</p><p>#{disagree}</p>), result
+  end
+
+  private
+
+  def abbr(abbr, title)
+    %(<abbr title="#{title}">#{abbr}</abbr>)
   end
 end


### PR DESCRIPTION
Add boundaries around words when substituting an abbreviation
